### PR TITLE
fix: Add context to keybinding

### DIFF
--- a/package.json
+++ b/package.json
@@ -157,7 +157,8 @@
       {
         "command": "inline-parameters.toggle",
         "key": "ctrl+k a",
-        "mac": "cmd+k a"
+        "mac": "cmd+k a",
+        "when": "editorFocus"
       }
     ]
   },


### PR DESCRIPTION
Fixes #38 by specifying a [context for the keybinding](https://vscode.readthedocs.io/en/latest/getstarted/keybindings/#when-clause-contexts).
